### PR TITLE
Implement DNS for squash microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,51 @@ The [squash-dash](https://github.com/lsst-sqre/squash-dash) is a frontend interf
 ![SQuaSH DB, API, Bokeh and the Dashboard microservices](figs/squash-deployment.png)
 
 
+## Configure DNS for the services
+
+We use AWS route53 to create DNS records for SQuaSH services. You have to set your 
+AWS credentials and execute the command below for each service:
+
+```
+export AWS_ACCESS_KEY_ID=<your AWS credentials>
+export AWS_SECRET_ACCESS_KEY=<your AWS credentials>
+```
+
+```
+SQUASH_SERVICE=<name of the squash service> make dns
+```
+
+Output example:
+
+```
+$ SQUASH_SERVICE=squash-bokeh make dns
+source terraform/tf_env.sh squash-bokeh squash-dev 35.203.172.87; 
+	./terraform/bin/terraform apply -state=terraform/squash-bokeh.tfstate terraform/dns
+aws_route53_record.squash-www: Creating...
+  fqdn:              "" => "<computed>"
+  name:              "" => "squash-bokeh.squash-dev.lsst.codes"
+  records.#:         "" => "1"
+  records.547640452: "" => "35.203.172.87"
+  ttl:               "" => "300"
+  type:              "" => "A"
+  zone_id:           "" => "Z3TH0HRSNU67AM"
+aws_route53_record.squash-www: Still creating... (10s elapsed)
+aws_route53_record.squash-www: Still creating... (20s elapsed)
+aws_route53_record.squash-www: Still creating... (30s elapsed)
+aws_route53_record.squash-www: Still creating... (40s elapsed)
+aws_route53_record.squash-www: Creation complete (ID: Z3TH0HRSNU67AM_squash-bokeh.squash-dev.lsst.codes_A)
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+
+```
+
+The DNS record can be removed with:
+
+```
+SQUASH_SERVICE=<name of the squash service> make remove-dns
+```
+
+
 ## Environment variables
 The following environment variables are used to exchange information among the pods:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ export AWS_SECRET_ACCESS_KEY=<your AWS credentials>
 SQUASH_SERVICE=<name of the squash service> make dns
 ```
 
+NOTE: The namespace `squash-prod` is reserved for production deployment and will
+be removed from the service name.
+
 Output example:
 
 ```

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,3 @@
+bin
+*tfstate*
+*.terraform

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,12 @@
+UNAME := $(shell uname -s | tr A-Z a-z)
+BIN_DIR=./bin
+TF_VERSION=0.9.11
+ZIP_FILE=terraform_$(TF_VERSION)_$(UNAME)_amd64.zip
+
+$(BIN_DIR):
+	mkdir $@
+	cd $@; wget https://releases.hashicorp.com/terraform/$(TF_VERSION)/$(ZIP_FILE)
+	cd $@; unzip $(ZIP_FILE)
+
+clean:
+	rm -rf bin

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "us-east-1"
+}
+
+resource "aws_route53_record" "squash-www" {
+  zone_id = "${var.aws_zone_id}"
+  name    = "${var.service_name}.${var.namespace_name}.${var.domain_name}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${var.external_ip}"]
+}

--- a/terraform/dns/main.tf
+++ b/terraform/dns/main.tf
@@ -6,7 +6,9 @@ provider "aws" {
 
 resource "aws_route53_record" "squash-www" {
   zone_id = "${var.aws_zone_id}"
-  name    = "${var.service_name}.${var.namespace_name}.${var.domain_name}"
+  # There's a special namespace, used for production deployment only, which will be removed from the
+  # name to produce ${var.service_name}.${var.domain_name}
+  name    = "${replace("${var.service_name}.${var.namespace_name}.${var.domain_name}", ".squash-prod", "")}"
   type    = "A"
   ttl     = "300"
   records = ["${var.external_ip}"]

--- a/terraform/dns/variables.tf
+++ b/terraform/dns/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_access_key" {
+  description = "AWS access key id."
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret access key."
+}
+
+variable "aws_zone_id" {
+  description = "route53 Hosted Zone ID to manage DNS records in."
+  default     = "Z3TH0HRSNU67AM"
+}
+
+variable "service_name" {
+  description = "Name of the service for which the DNS record is being created."
+}
+
+variable "namespace_name" {
+  description = "Kubernetes namespace, used to configure the resource name."
+}
+
+variable "domain_name" {
+  description = "DNS domain name to use when creating route53 records."
+  default     = "lsst.codes"
+}
+
+variable "external_ip" {
+  description = "External IP from the k8s squash service"
+}

--- a/terraform/tf_env.sh
+++ b/terraform/tf_env.sh
@@ -1,0 +1,9 @@
+SQUASH_SERVICE=$1
+NAMESPACE=$2
+EXTERNAL_IP=$3
+export TF_VAR_aws_access_key=$AWS_ACCESS_KEY_ID
+export TF_VAR_aws_secret_key=$AWS_SECRET_ACCESS_KEY
+export TF_VAR_service_name=$SQUASH_SERVICE
+export TF_VAR_namespace_name=$NAMESPACE
+export TF_VAR_external_ip=$EXTERNAL_IP
+


### PR DESCRIPTION
Creates AWS route53 resource for squash services.
After the service deployment the external IP is discovered and a DNS record following this pattern

```
${var.service_name}.${var.namespace_name}.${var.domain_name}
```

is created.

```

$ SQUASH_SERVICE=squash-bokeh make dns
--
 
source terraform/tf_env.sh squash-bokeh squash-dev 35.203.172.87;
./terraform/bin/terraform apply -state=terraform/squash-bokeh.tfstate terraform/dns
aws_route53_record.squash-www: Creating...
fqdn:              "" => "<computed>"
name:              "" => "squash-bokeh.squash-dev.lsst.codes"
records.#:         "" => "1"
records.547640452: "" => "35.203.172.87"
ttl:               "" => "300"
type:              "" => "A"
zone_id:           "" => "Z3TH0HRSNU67AM"
aws_route53_record.squash-www: Still creating... (10s elapsed)
aws_route53_record.squash-www: Still creating... (20s elapsed)
aws_route53_record.squash-www: Still creating... (30s elapsed)
aws_route53_record.squash-www: Still creating... (40s elapsed)
aws_route53_record.squash-www: Creation complete (ID: Z3TH0HRSNU67AM_squash-bokeh.squash-dev.lsst.codes_A)
 
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

