### PR TITLE
[DM-16449] Instrument the SQuaSH API with telegraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 Short instructions in case you are familiar with the [SQuaSH](https://squash.lsst.codes/) deployment:
 ```
 # Make sure kubectl is configured to access your GKE cluster
- 
+
 # Set an appropriate namespace for the deployment
 export NAMESPACE=demo
-make namespace 
- 
+make namespace
+
 # Create the TLS certificate secrets used by the SQuaSH services
 
 # Download the `lsst-certs.git` repo containing the most recent SSL certificates (or ask SQuaRE if you don't know about it)
 # Make sure the folder is unzipped
 make tls-certs
- 
+
 # Deploy the SQuaSH REST API
-SQUASH_SERVICE=squash-restful-api make clone 
+SQUASH_SERVICE=squash-restful-api make clone
 
 cd squash-restful-api
 
@@ -34,11 +34,11 @@ make aws-secret
 
 # Create the S3 bucket for this deployment
 make s3-bucket  
-  
+
 # Set the application default user
 export SQUASH_DEFAULT_USER=<the squash api admin user>
 export SQUASH_DEFAULT_PASSWORD=<password for the squash api admin user>
- 
+
 TAG=latest make service deployment
 
 # Create the service name
@@ -46,25 +46,25 @@ cd ..
 
 export SQUASH_SERVICE=squash-restful-api
 make name
- 
+
 # Deploy the bokeh server
 SQUASH_SERVICE=squash-bokeh make clone deployment name
- 
-# Deploy the SQuaSH frontend 
+
+# Deploy the SQuaSH frontend
 SQUASH_SERVICE=squash make clone deployment name
 ```
 
 ## squash-deployment
 
-This tool automates [SQuaSH](https://squash.lsst.codes/) deployment helping you  cloning the repositories involved, setting up the appropriate 
+This tool automates [SQuaSH](https://squash.lsst.codes/) deployment helping you  cloning the repositories involved, setting up the appropriate
 deployment namespace, creating secrets and custom configurations.
 
-If you are not familiar with microservices or k8s concepts, a good resource is this [tutorial](https://classroom.udacity.com/courses/ud615) from Kelsey Hightower. 
+If you are not familiar with microservices or k8s concepts, a good resource is this [tutorial](https://classroom.udacity.com/courses/ud615) from Kelsey Hightower.
 
 ### Requirements
 
 We assume that you have a k8s cluster on [GKE](https://cloud.google.com/kubernetes-engine/) and the required tools installed, like the [Google Cloud SDK](https://cloud.google.com/sdk/), Docker and the [kubectl](https://kubernetes.io/docs/user-guide/kubectl-overview/) client.
- 
+
 To configure `kubectl` to connect to your cluster go to [Google Cloud Platform](https://cloud.google.com) > Google Kubernetes Clusters, select your cluster and click `Connect` to get the cluster credentials.
 
 We also assume that you have your AWS credentials - we use AWS route53 for DNS configuration and AWS S3 to store verification datasets sent to SQuaSH.
@@ -78,10 +78,10 @@ Namespaces are also used to define the context in which the `kubectl` client wor
 Use the following to create a `demo` namespace and context:
 
 ```
-NAMESPACE=demo make namespace 
+NAMESPACE=demo make namespace
 ```
- 
-Output example: 
+
+Output example:
 
 ```
 $ NAMESPACE=demo make namespace
@@ -96,7 +96,7 @@ Switched to context "demo".
 
 You can switch to an existing namespace using:
 ```
-NAMESPACE=demo make switch-namespace 
+NAMESPACE=demo make switch-namespace
 ```
 
 And a namespace can be removed with:
@@ -112,14 +112,14 @@ NOTE: There's a reserved namespace, `squash-prod` used for the production deploy
 
 ### Create the `tls-certs` secret
 
-TLS termination is implemented in the [squash-api](https://github.com/lsst-sqre/squash-api), [squash-bokeh](https://github.com/lsst-sqre/squash-bokeh) and [squash-dash](https://github.com/lsst-sqre/squash-dash) microservices to secure traffic on the `*.lsst.codes` domain. 
+TLS termination is implemented in the [squash-api](https://github.com/lsst-sqre/squash-api), [squash-bokeh](https://github.com/lsst-sqre/squash-bokeh) and [squash-dash](https://github.com/lsst-sqre/squash-dash) microservices to secure traffic on the `*.lsst.codes` domain.
 
-The SSL key and certificates for the `*.lsst.codes` domain name can be downloaded from this bare repo at [lsst-certs](https://www.dropbox.com/home/lsst-sqre/git) 
+The SSL key and certificates for the `*.lsst.codes` domain name can be downloaded from this bare repo at [lsst-certs](https://www.dropbox.com/home/lsst-sqre/git)
 
-You'll have to sign in to Dropbox to download the `lsst-certs.git`, make sure it is in the current directory and is unziped. 
+You'll have to sign in to Dropbox to download the `lsst-certs.git`, make sure it is in the current directory and is unziped.
 
 Then use the following command to create the `tls-certs` secret.
- 
+
 ```
 make tls-certs
 ```
@@ -152,19 +152,19 @@ secret "tls-certs" created
 Follow each microservice repository for detailed deployment instructions.
 
 
-* [squash-restful-api](https://github.com/lsst-sqre/squash-restful-api): The SQuaSH RESTful API is a Flask application used to manage the metrics dashboard. It also uses Celery to enable the execution of tasks in background. 
+* [squash-restful-api](https://github.com/lsst-sqre/squash-restful-api): The SQuaSH RESTful API is a Flask application used to manage the metrics dashboard. It also uses Celery to enable the execution of tasks in background.
 
 * [squash-bokeh](https://github.com/lsst-sqre/squash-bokeh): it serves the squash bokeh apps, we use the Bokeh plotting library for rich interactive visualizations.
 
-* [squash](https://github.com/lsst-sqre/squas) is the web frontend to embed the bokeh apps and navigate through the bokeh apps. 
+* [squash](https://github.com/lsst-sqre/squas) is the web frontend to embed the bokeh apps and navigate through the bokeh apps.
 
 
 ![SQuaSH deployment architecture](figs/squash-deployment.png)
 
 ## Creating names for the services
 
-We use AWS route53 to create DNS records for the SQuaSH services. You have to set your 
-AWS credentials and execute the command below for the `squash-restful-api`, `squash-bokeh` 
+We use AWS route53 to create DNS records for the SQuaSH services. You have to set your
+AWS credentials and execute the command below for the `squash-restful-api`, `squash-bokeh`
 and `squash` services.
 
 ```
@@ -176,16 +176,16 @@ export AWS_SECRET_ACCESS_KEY=<your AWS credentials>
 NASMESPACE=<namespace> SQUASH_SERVICE=<name of the squash service> make name
 ```
 
-Service names follow the pattern `<squash service>-<namespace>.lsst.codes`. 
+Service names follow the pattern `<squash service>-<namespace>.lsst.codes`.
 
-For the production deployment, which uses the reserved namespace `<squash-prod>` the  services will be named like `<squash service>.lsst.codes`. 
+For the production deployment, which uses the reserved namespace `<squash-prod>` the  services will be named like `<squash service>.lsst.codes`.
 
 Output example:
 
 ```
 $ NAMESPACE=demo SQUASH_SERVICE=squash-bokeh make name
 ---
-source terraform/tf_env.sh squash-bokeh demo 35.203.172.87; 
+source terraform/tf_env.sh squash-bokeh demo 35.203.172.87;
 	./terraform/bin/terraform apply -state=terraform/squash-bokeh.tfstate terraform/dns
 aws_route53_record.squash-www: Creating...
   fqdn:              "" => "<computed>"
@@ -216,6 +216,26 @@ NAMESPACE=<namespace> SQUASH_SERVICE=<name of the squash service> make remove-na
 That's it, you should be able to access SQuaSH from `https://squash-<namespace>.lsst.codes`.
 
 
+# Deploying Telegraf for monitoring
+
+Deploy Tiller, the server portion of Helm.
+
+You can do that on the `kube-system` namespace, and create a service account with `cluster-admin` role, but see [Helm and RBAC](https://docs.helm.sh/using_helm/#role-based-access-control) for other options.
+
+```
+kubectl create -f kubernetes/rbac-config.yaml
+helm init --service-account tiller
+```
+
+Deploy Telegraf
+
+```
+helm install ./telegraf-ds
+```
+
+See [telegraf-ds](telegraf-ds/README.md) for more information.
+
+
 # Updating SSL certificates
 
 - Go to squash-deployment folder used to deploy a particular SQuaSH instance
@@ -223,5 +243,3 @@ That's it, you should be able to access SQuaSH from `https://squash-<namespace>.
 - Update `LSST_CERTS_YEAR` variable to the current year in the Makefile
 - Remove the previous `tls` folder
 - Run make `tls-certs`
-
-

--- a/kubernetes/rbac-config.yaml
+++ b/kubernetes/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/telegraf-ds/Chart.yaml
+++ b/telegraf-ds/Chart.yaml
@@ -1,0 +1,12 @@
+name: telegraf-ds
+version: 1.8.3
+description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
+keywords:
+- telegraf
+- metric collector
+- timeseries
+- influxdb
+home: https://www.influxdata.com/time-series-platform/telegraf/
+maintainers:
+- name: Angelo Fausti
+  email: afausti@lsst.org

--- a/telegraf-ds/README.md
+++ b/telegraf-ds/README.md
@@ -1,0 +1,47 @@
+# Telegraf DaemonSet
+
+[Telegraf](https://github.com/influxdata/telegraf) is a plugin-driven server agent written by the folks over at [InfluxData](https://influxdata.com) for collecting & reporting metrics. This chart runs a DaemonSet of Telegraf instances to collect host level metrics for your cluster.
+
+## TL;DR
+
+```console
+$ helm install ./telegraf-ds
+```
+
+## Introduction
+
+This chart bootstraps a `telegraf-ds` deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.6  + with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release ./telegraf-ds
+```
+
+The command deploys a Telegraf daemonset on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section as well as the [values.yaml](/values.yaml) file lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Telegraf Configuration
+
+This chart deploys the following by default:
+
+- `telegraf-ds` running in a daemonset with the following plugins enabled
+  * [`docker`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker)
+  * [`kubernetes`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/kubernetes)

--- a/telegraf-ds/templates/NOTES.txt
+++ b/telegraf-ds/templates/NOTES.txt
@@ -1,0 +1,11 @@
+To open a shell session in the container running Telegraf run the following:
+
+- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{.items[0].metadata.name}') /bin/sh
+
+To tail the logs for a Telegraf pod in the Daemonset run the following:
+
+- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{ .items[0].metadata.name }')
+
+To list the running Telegraf instances run the following:
+
+- kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -w

--- a/telegraf-ds/templates/_helpers.tpl
+++ b/telegraf-ds/templates/_helpers.tpl
@@ -1,0 +1,147 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
+
+{{/*
+  CUSTOM TEMPLATES: This section contains templates that make up the different parts of the telegraf configuration file.
+  - global_tags section
+  - agent section
+*/}}
+
+{{- define "outputs" -}}
+{{- range $outputIdx, $configObject := . -}}
+{{- range $output, $config := . }}
+    [[outputs.{{ $output }}]]
+  {{- if $config }}
+  {{- $tp := typeOf $config -}}
+  {{- if eq $tp "map[string]interface {}" -}}
+    {{- range $key, $value := $config -}}
+      {{- $tp := typeOf $value }}
+      {{- if eq $tp "string"}}
+      {{ $key }} = {{ $value | quote }}
+      {{- end }}
+      {{- if eq $tp "float64"}}
+      {{ $key }} = {{ $value | int64 }}
+      {{- end }}
+      {{- if eq $tp "int"}}
+      {{ $key }} = {{ $value | int64 }}
+      {{- end }}
+      {{- if eq $tp "bool"}}
+      {{ $key }} = {{ $value }}
+      {{- end }}
+      {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+          {{- $numOut := len $value }}
+          {{- $numOut := sub $numOut 1 }}
+          {{- range $b, $val := $value }}
+            {{- $i := int64 $b }}
+            {{- if eq $i $numOut }}
+        {{ $val | quote }}
+            {{- else }}
+        {{ $val | quote }},
+            {{- end }}
+          {{- end }}
+      ]
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "inputs" -}}
+{{- range $inputIdx, $configObject := . -}}
+    {{- range $input, $config := . -}}
+      
+    [[inputs.{{- $input }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- if eq $tp "map[string]interface {}" }}
+      [[inputs.{{ $input }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $value }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- if eq $i $numOut }}
+            {{ $val | quote }}
+                  {{- else }}
+            {{ $val | quote }},
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [[inputs.{{ $input }}.{{ $key }}.{{ $k }}]]
+                {{- range $foo, $bar := $v }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}

--- a/telegraf-ds/templates/configmap.yaml
+++ b/telegraf-ds/templates/configmap.yaml
@@ -1,0 +1,35 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  telegraf.conf: |+
+    {{- if .Values.config.global_tags }}
+    [global_tags]
+      {{- range $key, $val := .Values.config.global_tags }}
+      {{ $key }} = {{ $val | quote }}
+      {{- end }}
+    {{- end }}
+    [agent]
+      interval = {{ .Values.config.agent.interval | quote }}
+      round_interval = {{ .Values.config.agent.round_interval }}
+      metric_batch_size = {{ .Values.config.agent.metric_batch_size }}
+      metric_buffer_limit = {{ .Values.config.agent.metric_buffer_limit }}
+      collection_jitter = {{ .Values.config.agent.collection_jitter | quote }}
+      flush_interval = {{ .Values.config.agent.flush_interval | quote }}
+      flush_jitter = {{ .Values.config.agent.flush_jitter | quote }}
+      precision = ""
+      debug = false
+      quiet = true
+      logfile = ""
+      hostname = "$HOSTNAME"
+      omit_hostname = false
+
+    {{ template "outputs" .Values.config.outputs }}
+    {{ template "inputs" .Values.config.inputs -}}

--- a/telegraf-ds/templates/daemonset.yaml
+++ b/telegraf-ds/templates/daemonset.yaml
@@ -1,0 +1,75 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+      annotations:
+        # Include a hash of the configmap in the pod template
+        # This means that if the configmap changes, the deployment will be rolled
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        # This pulls HOSTNAME from the node, not the pod.
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # In test clusters where hostnames are resolved in /etc/hosts on each node,
+        # the HOSTNAME is not resolvable from inside containers
+        # So inject the host IP as well
+        - name: HOSTIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: "HOST_PROC"
+          value: "/rootfs/proc"
+        - name: "HOST_SYS"
+          value: "/rootfs/sys"
+        volumeMounts:
+        - name: varrunutmpro
+          mountPath: /var/run/utmp
+          readOnly: true
+        - name: sysro
+          mountPath: /rootfs/sys
+          readOnly: true
+        - name: procro
+          mountPath: /rootfs/proc
+          readOnly: true
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+        - name: config
+          mountPath: /etc/telegraf
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: sysro
+        hostPath:
+          path: /sys
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+      - name: procro
+        hostPath:
+          path: /proc
+      - name: varrunutmpro
+        hostPath:
+          path: /var/run/utmp
+      - name: config
+        configMap:
+          name: {{ template "fullname" . }}

--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -1,0 +1,58 @@
+## Default values.yaml for Telegraf
+## This is a YAML-formatted file.
+## ref: https://hub.docker.com/r/library/telegraf/tags/
+image:
+  repo: "telegraf"
+  tag: "1.8.3-alpine"
+  pullPolicy: IfNotPresent
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 0.1
+  limits:
+    memory: 2Gi
+    cpu: 1
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Exposed telegraf configuration
+## ref: https://docs.influxdata.com/telegraf/v1.8/administration/configuration/
+config:
+  # global_tags:
+  #   cluster: "mycluster"
+  agent:
+    interval: "10s"
+    round_interval: true
+    metric_batch_size: 1000
+    metric_buffer_limit: 10000
+    collection_jitter: "0s"
+    flush_interval: "10s"
+    flush_jitter: "0s"
+  outputs:
+    - influxdb:
+        url: "https://influxdb-demo.lsst.codes"
+        database: "telegraf"
+        retention_policy: ""
+        timeout: "5s"
+        username: ""
+        password: ""
+        user_agent: "telegraf"
+        insecure_skip_verify: false
+  inputs:
+    - kubernetes:
+        url: "http://$HOSTIP:10255"
+        bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        insecure_skip_verify: true
+    - docker:
+        endpoint: "unix:///var/run/docker.sock"
+        timeout: "5s"
+        perdevice: true
+        total: false
+        docker_label_exclude:
+          - "annotation.kubernetes.io/*"


### PR DESCRIPTION
Added telegraf for monitoring the SQuaSH deployment. Telegraf is deployed as a DaemonSet so that it runs as an agent on each node of the cluster collecting metrics from the kubernetes and docker input plugins. See https://github.com/influxdata/telegraf for more info.